### PR TITLE
修复PHP7下的兼容性错误

### DIFF
--- a/CFGGenerator.php
+++ b/CFGGenerator.php
@@ -920,7 +920,7 @@ class FunctionVisitor extends PhpParser\NodeVisitorAbstract{
 			        $this->fileSummary->getIncludeMap()
 			    );
 			    
-			    if(!$funcBody) break ;
+			    if(!$funcBody) return False ;
 			    $cfg = new CFGGenerator() ;
 			    //$this->block->function[$nodeName]
 			    $arr = $this->sinkContext->getAllSinks() ;


### PR DESCRIPTION
PHP 5.x.x, a break statement outside a for, foreach or switch statement DID NOT throw an error message and was syntactically okay.
PHP 7.0 and higher, a break statement is no longer permitted outside a for, foreach or switch statement and gives a fatal error.

So I replace break with return false